### PR TITLE
あらかじめ設定したステータス情報のフォーマットが有効にならない

### DIFF
--- a/plugin/anzu.vim
+++ b/plugin/anzu.vim
@@ -8,7 +8,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 
-let g:anzu_status_format = get(g:, "g:anzu_status_format", "%p(%i/%l)")
+let g:anzu_status_format = get(g:, "anzu_status_format", "%p(%i/%l)")
 
 
 command! -bar AnzuClearSearchStatus call anzu#clear_search_status()


### PR DESCRIPTION
g:anzu_status_format を get() する際の変数名の指定を修正しました。
