### PR TITLE
Escape backslash

### DIFF
--- a/autoload/anzu.vim
+++ b/autoload/anzu.vim
@@ -31,6 +31,7 @@ function! anzu#update(pattern, cursor_pos)
 		return
 	endif
 
+	let l:pattern = substitute(pattern, '\\', '\\\\', 'g')
 	let s:status_cache = substitute(substitute(substitute(g:anzu_status_format, "%p", pattern, "g"), "%i", index+1, "g"), "%l", len(pos_all), "g")
 endfunction
 


### PR DESCRIPTION
/\vhoge と検索すると anzu#search_status() で返ってくる文字列が
vhoge になってしまうため、エスケープさせました。
s/\.//g も考えましたが、\aや\dなどは表示させた方が望ましいと思ったため上記の動作にしてあります。
