### PR TITLE
do not reset curswant after s:searchpos() calls

### DIFF
--- a/autoload/anzu.vim
+++ b/autoload/anzu.vim
@@ -186,7 +186,8 @@ endfunction
 
 
 function! s:searchpos_all(pattern)
-	let old_pos =getpos(".")
+	" winsave view correctly restores curswant
+	let old_pos = winsaveview()
 	let result = []
 	try
 		call setpos(".", [0, line("$"), strlen(getline("$")), 0])
@@ -201,7 +202,7 @@ function! s:searchpos_all(pattern)
 			endif
 		endwhile
 	finally
-		call setpos(".", old_pos)
+		call winrestview(old_pos)
 	endtry
 	return result
 endfunction


### PR DESCRIPTION
when s:searchpos() was called after a cursormoved event, this would
reset the actually wanted column. Take this example:

,----
| a long line with many text characters!
| a shorter line
| along line with many text characters!
`----

Put the cursor on the '!' of the first line, replace by '.' using 'r.'
now move down two lines: '2j'
Expected result: cursor is on the '!' of the third line.
Actual result: cursor is on the t of with

This can be prevented by using winsaveview(), which among other things,
does reset the curswant attribute to the correct value.